### PR TITLE
Fix PR template link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 <!--- Put an `x` in all the boxes that apply -->
 - [ ] My change requires a change to the documentation.
     - [ ] I have updated the documentation accordingly.
-    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_preview.html).
+    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html).
 - [ ] I have assigned and requested two reviewers for this pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 <!--- Put an `x` in all the boxes that apply -->
 - [ ] My change requires a change to the documentation.
     - [ ] I have updated the documentation accordingly.
-    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
+    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_preview.html).
 - [ ] I have assigned and requested two reviewers for this pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 <!--- Put an `x` in all the boxes that apply -->
 - [ ] My change requires a change to the documentation.
     - [ ] I have updated the documentation accordingly.
-    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html).
+    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
 - [ ] I have assigned and requested two reviewers for this pull request.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Fixes the PR template link following a recent docs restructure.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
